### PR TITLE
SMALL FIXES

### DIFF
--- a/layouts/_default/limage.html
+++ b/layouts/_default/limage.html
@@ -1,8 +1,9 @@
 <div class="col-lg-4 col-sm-6">
     {{ $path := replace .Dir "\\" "/" }}
     <a href="/{{ $path }}" class="project-box project-link">
-        {{ if .Params.small_image }}
-            {{ $image := .Resources.GetMatch .Params.small_image }}
+        {{ $image_file := or .Params.cover_image .Params.small_image }}
+        {{ if $image_file }}
+            {{ $image := .Resources.GetMatch $image_file }}
             {{ with $image }}
                 <img src="{{ .RelPermalink | relURL }}" class="img-responsive" alt="{{ .Name }}">
             {{ end }}

--- a/layouts/partials/sections/skills.html
+++ b/layouts/partials/sections/skills.html
@@ -40,12 +40,8 @@
                     {{ $label := or $data.tags_label "TAGS" }}
                     <h4>{{ $label }}</h4>
                     <div class="tags">
-                        {{ range $project_sections }}
-                            {{ with $.Site.GetPage "section" . }}
-                                {{ $params := (dict "type" "tags" "context" . "scratch" .Scratch "removeDuplicates" true) }}
-                                {{ partial "utils/list-keywords.html" $params }}
-                            {{ end }}
-                        {{ end }}
+                        {{ $params := (dict "type" "tags" "context" $project_sections "site" $.Site "scratch" .Scratch "removeDuplicates" true) }}
+                        {{ partial "utils/list-keywords-range.html" $params }}
                     </div>
                 </div>
             </div>
@@ -55,12 +51,8 @@
                     {{ $label := or $data.categories_label "CATEGORIES" }}
                     <h4>{{ $label }}</h4>
                     <div class="tags">
-                        {{ range $project_sections }}
-                            {{ with $.Site.GetPage "section" . }}
-                                {{ $params := (dict "type" "categories" "context" . "scratch" .Scratch "removeDuplicates" true) }}
-                                {{ partial "utils/list-keywords.html" $params }}
-                            {{ end }}
-                        {{ end }}
+                        {{ $params := (dict "type" "categories" "context" $project_sections "site" $.Site "scratch" .Scratch "removeDuplicates" true) }}
+                        {{ partial "utils/list-keywords-range.html" $params }}
                     </div>
                 </div>
             </div>

--- a/layouts/partials/utils/list-keywords-range.html
+++ b/layouts/partials/utils/list-keywords-range.html
@@ -1,0 +1,24 @@
+{{/*
+    Parameters:
+    - type: "tags" or "categories"
+    - context: (project_sections)
+    - site: (Site)
+    - scratch: (Scratch)
+    - removeDuplicates: BOOL
+*/}}
+
+{{ .scratch.Delete .type }}
+{{ range .context }}
+    {{ with $.site.GetPage "section" . }}
+        {{ $params := (dict "type" $.type "context" . "scratch" $.scratch "removeDuplicates" $.removeDuplicates) }}
+        {{ partial "utils/get-keywords.html" $params }}
+    {{ end }}
+{{ end }}
+{{ .scratch.Set .type (uniq (.scratch.Get .type)) }}
+
+{{ range (.scratch.Get .type) }}
+    <a href="{{ (print "/" $.type "/") | relLangURL }}{{ . | urlize }}" title="{{ . }}">
+        {{ . }}
+    </a>
+{{ end }}
+{{ .scratch.Delete .type }}


### PR DESCRIPTION
- Fixed the duplicate keywords issue in both "TAGS" and "CATEGORIES" lists in the "skills section.
- Allow to have a specific image for each project (different than "small_image") in "project" sections.