### PR TITLE
Minify fixes

### DIFF
--- a/layouts/partials/sections/contact.html
+++ b/layouts/partials/sections/contact.html
@@ -35,11 +35,11 @@
                                     {{ if .icon }}
                                         {{ $pack := or .icon_pack "fa" }}
                                         <i class="{{ $pack }} {{ .icon }}" aria-hidden="true">
-                                    {{ else }}
-                                        <i class="fa" aria-hidden="true">
-                                    {{ end }}
-                                        {{ .address }}
+                                            <div>{{ .address }}</div>
                                         </i>
+                                    {{ else }}
+                                        <i class="fa" aria-hidden="true">{{ .address }}</i>
+                                    {{ end }}
                                     {{ if .link }}
                                     </a>
                                     {{ end }}

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1561,7 +1561,8 @@ margin-bottom: 2em;
     font-family: var(--SIDEBAR-FONT, var(--GENERAL-FONT-2));
 }
 .sidebar-bottom .sidebar-tree li:not(:last-of-type)::after {
-    content: "\2022";
+    white-space: pre;
+    content: "\20\2022\20";
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
When deploying, minifying is applied, causing some differences between local site (not minified) and deployed site.
Differences with spaces being removed.

Fixes:
- posts: spaces between 'li' in bottom-sidebar
- contact: email address, space between icon and text
